### PR TITLE
Piratmac/fix error 500

### DIFF
--- a/server/src/sonos/MusicLibrary.js
+++ b/server/src/sonos/MusicLibrary.js
@@ -70,6 +70,9 @@ class MusicLibrary {
           case 'albumArtists':
           case 'genres':
           case 'playlists':
+          case 'share':
+            break
+          default:
             await Promise.all(result.items.map(async (item, index) => {
               try {
                 // Get the album art
@@ -85,8 +88,6 @@ class MusicLibrary {
                 }
               }
             }));
-            break;
-          default:
             break;
         }
       }

--- a/server/src/sonos/MusicLibrary.js
+++ b/server/src/sonos/MusicLibrary.js
@@ -65,11 +65,11 @@ class MusicLibrary {
       // eslint-disable-next-line max-len
       const result = await this.sonos.searchMusicLibrary(category, searchTerm, options.searchOptions, separator);
       if (!result) return MusicLibrary._getEmptyReturnResult();
-      if (options.getAlbumArt) {
+      if (options.getAlbumArt && result.items) {
         switch (options.searchCategory) {
           case 'albumArtists':
           case 'genres':
-          //case 'playlists':
+          case 'playlists':
             await Promise.all(result.items.map(async (item, index) => {
               try {
                 // Get the album art
@@ -117,7 +117,7 @@ class MusicLibrary {
         searchOptions: { start: 0, total },
         search: true,
       });
-      if (result.items.length) {
+      if (result.items && result.items.length) {
         topResults[item] = result;
       }
     }));
@@ -172,6 +172,7 @@ class MusicLibrary {
     };
     const options = { ...defaultOptions, ...searchOptions };
     if (this._sonosPlaylistCache) {
+      if (!this._sonosPlaylistCache.items) return MusicLibrary._getEmptyReturnResult();
       const items = this._sonosPlaylistCache.items.slice(options.start, options.total);
       return {
         total: String(this._sonosPlaylistCache.length),
@@ -183,6 +184,7 @@ class MusicLibrary {
       const playlists = await this.sonos.getMusicLibrary('sonos_playlists');
       if (!playlists) throw new Error(NoResultsFound);
       this._sonosPlaylistCache = playlists;
+      if (!playlists.items) return MusicLibrary._getEmptyReturnResult();
       const items = playlists.items.slice(options.start, options.total);
       return {
         total: String(playlists.length),

--- a/server/src/sonos/MusicLibrary.js
+++ b/server/src/sonos/MusicLibrary.js
@@ -69,7 +69,7 @@ class MusicLibrary {
         switch (options.searchCategory) {
           case 'albumArtists':
           case 'genres':
-          case 'playlists':
+          //case 'playlists':
             await Promise.all(result.items.map(async (item, index) => {
               try {
                 // Get the album art


### PR DESCRIPTION
I have tried to fix the error 500 that appear in various pages.
Based on my analysis, the issue is because the system tries to find album art for playlists, shares, artists and genres. Those categories do not have album art.
I have "reversed" the condition: for all those elements, no album art will be fetched. Therefore, it'll search for album art for songs & albums only.