### PR TITLE
Added aarch64 and armv7 support for Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,4 +55,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm/7
+          platforms: linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,4 +51,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: {{ matrix.arch }}
+          platforms: ${{ matrix.arch }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,20 +8,31 @@ jobs:
     name: docker
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        arch: [arm, arm64, x86, x86_64]
-
+    # strategy:
+    #   matrix:
+    #     include:
+    #       - arch: aarch64
+    #         distro: ubuntu_latest
+    #       - arch: armv7
+    #         distro: ubuntu_latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Set up QEMU dependency
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Get version from `package.json`
         id: pkgversion
         run: |
           PKG_VERSION=$(jq -r .version client/package.json)
           echo "$PKG_VERSION"
           echo "::set-output name=PKG_VERSION::$PKG_VERSION"
+
       - name: Generate docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -30,11 +41,13 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=${{ steps.pkgversion.outputs.PKG_VERSION }}
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
@@ -42,3 +55,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm/7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,10 +7,21 @@ jobs:
   build-and-publish:
     name: docker
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu_latest
+          - arch: armv7
+            distro: ubuntu_latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Get version from `package.json`
+      
+      - uses: uraimo/run-on-arch-action@v2
+        name: Get version from `package.json`
         id: pkgversion
         run: |
           PKG_VERSION=$(jq -r .version client/package.json)
@@ -20,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: sonosweb/sonos-web
+          images: zegorax/sonos-web
           tags: |
             type=raw,value=latest
             type=raw,value=${{ steps.pkgversion.outputs.PKG_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,18 +10,13 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - arch: aarch64
-            distro: ubuntu_latest
-          - arch: armv7
-            distro: ubuntu_latest
+        arch: [arm, arm64, x86, x86_64]
+
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      
-      - uses: uraimo/run-on-arch-action@v2
-        name: Get version from `package.json`
+      - name: Get version from `package.json`
         id: pkgversion
         run: |
           PKG_VERSION=$(jq -r .version client/package.json)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,4 +51,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.arch }}
+          platforms: linux/${{ matrix.arch }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,13 +8,9 @@ jobs:
     name: docker
     runs-on: ubuntu-latest
 
-    # strategy:
-    #   matrix:
-    #     include:
-    #       - arch: aarch64
-    #         distro: ubuntu_latest
-    #       - arch: armv7
-    #         distro: ubuntu_latest
+    strategy:
+      matrix:
+        arch: ["arm64", "arm/v7","amd64"]
 
     steps:
       - name: Checkout code
@@ -55,4 +51,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64
+          platforms: {{ matrix.arch }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: zegorax/sonos-web
+          images: sonosweb/sonos-web
           tags: |
             type=raw,value=latest
             type=raw,value=${{ steps.pkgversion.outputs.PKG_VERSION }}


### PR DESCRIPTION
This PR introduces the support of the aarch64 and armv7 architectures for the main Docker image.

It is using QEMU-emulation to replicate the architectures and therefore will take a longer time to build compared to the standard amd64 image.